### PR TITLE
Allow setting renderer default in the plugin configuration line

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ in you application and then specify the renderer to Will Paginate:
 
 ```
 
+Alternative you can set it in the plugin configuration to avoid repeating it
+in each helper call:
+
+```ruby
+plugin :will_paginate, renderer: Roda::WillPaginate::BootstrapPaginationRenderer
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/manuca/roda-will_paginate/fork )

--- a/lib/roda/plugins/will_paginate.rb
+++ b/lib/roda/plugins/will_paginate.rb
@@ -3,12 +3,19 @@ require 'will_paginate/view_helpers/link_renderer'
 class Roda
   module RodaPlugins
     module WillPaginate
+
+      def self.configure(app, opts = {})
+        app.opts[:will_paginate] = opts.dup
+
+        opts = app.opts[:will_paginate]
+        opts[:renderer] ||= ::Roda::WillPaginate::LinkRenderer
+      end
+
       module InstanceMethods
         include ::WillPaginate::ViewHelpers
 
         def will_paginate(collection, options = {}) #:nodoc:
-          options = options.merge(:renderer => ::Roda::WillPaginate::LinkRenderer) unless options[:renderer]
-          super(collection, options)
+          super(collection, opts[:will_paginate].merge(options))
         end
       end
     end


### PR DESCRIPTION
I wanted to avoid having to specify my renderer in every helper call so I added an options hash
that can be set in the plugin line.

You can still override it in the helper call and it still works fine just as it did before.
