### PR TITLE
Correct html structure for bootstrap

### DIFF
--- a/lib/roda/will_paginate/bootstrap_pagination_renderer.rb
+++ b/lib/roda/will_paginate/bootstrap_pagination_renderer.rb
@@ -23,12 +23,17 @@ class Roda
         if page
           tag(:li, link(text, page, :class => classname))
         else
-          tag(:li, link(text, '#', :class => classname + ' disabled'))
+          tag(:li, link(text, '#', :class => classname), class: 'disabled')
         end
       end
 
       def html_container(html)
         tag(:ul, html, container_attributes)
+      end
+
+      def gap
+        text = @template.will_paginate_translate(:page_gap) { '&hellip;' }
+        %(<li class="disabled"><a href="#" class="gap">#{text}</a></li>)
       end
     end
   end


### PR DESCRIPTION
- moved disabled class from a tag to li tag
- corrected gap method
